### PR TITLE
Add better json logging.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.1.3 - 2020-01-09
+- Changed JSON logging to run everything through structlog
+
 ## 0.1.2 - 2019-12-27
 - Added namespace relative patcher and stricter linting/testing
 

--- a/src/miscutils/logging_config.py
+++ b/src/miscutils/logging_config.py
@@ -36,9 +36,42 @@ class Verbosity(IntEnum):
         v = self.value
         return VERBOSE_LEVELS[v] if v < len(VERBOSE_LEVELS) else VERBOSE_LEVELS[-1]
 
+def add_line_no(logger, method_name, event_dict):
+    """
+    Add the line number to the event dict.
+    """
+    record = event_dict.get("_record")
+    if record is not None:
+        event_dict["lineno"] = record.lineno
+    return event_dict
+
+def add_file_name(logger, method_name, event_dict):
+    """
+    Add the file name to the event dict.
+    """
+    record = event_dict.get("_record")
+    if record is not None:
+        event_dict["filename"] = record.filename
+    return event_dict
+
+
+pre_chain = [
+    add_line_no,
+    add_file_name,
+    structlog.stdlib.add_logger_name,
+    structlog.stdlib.add_log_level,
+    structlog.stdlib.PositionalArgumentsFormatter(),
+    structlog.processors.StackInfoRenderer(),
+    structlog.processors.format_exc_info,
+    structlog.processors.UnicodeDecoder(),
+]
+
 
 def default_logging(
-    verbosity: int, log_format: LogFormat = LogFormat.TEXT, external_logs: Iterable[str] = None
+    verbosity: int,
+    log_format: LogFormat = LogFormat.TEXT,
+    external_logs: Iterable[str] = None,
+    override_logs: Iterable[str] = None,
 ) -> None:
     """
     Configure structlog based on the given parameters.
@@ -49,6 +82,7 @@ def default_logging(
     :param log_format: Format to logs should be written in.
     :param external_logs: External modules that should have logging turned down unless verbosity is
         set to highest level.
+    :param override_logs: Loggers that need to have their handlers overridden.
     """
     level = Verbosity(verbosity).level()
 
@@ -58,47 +92,36 @@ def default_logging(
             logger_factory=structlog.stdlib.LoggerFactory(),
             wrapper_class=structlog.stdlib.BoundLogger,
             cache_logger_on_first_use=True,
-            processors=[
-                structlog.stdlib.filter_by_level,
-                structlog.stdlib.PositionalArgumentsFormatter(),
-                structlog.processors.StackInfoRenderer(),
-                structlog.processors.format_exc_info,
-                structlog.processors.UnicodeDecoder(),
-                structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-            ],
+            processors=pre_chain,
         )
     elif log_format == LogFormat.JSON:
-        # Setup json logging.
-        logging.config.dictConfig(
-            {
-                "version": 1,
-                "formatters": {
-                    "json": {
-                        "format": "%(message)s $(lineno)d $(filename)s",
-                        "class": "pythonjsonlogger.jsonlogger.JsonFormatter",
-                    }
-                },
-                "handlers": {"json": {"class": "logging.StreamHandler", "formatter": "json"}},
-                "loggers": {"": {"handlers": ["json"], "level": level}},
-            }
-        )
-
         structlog.configure(
             context_class=structlog.threadlocal.wrap_dict(dict),
             logger_factory=structlog.stdlib.LoggerFactory(),
             wrapper_class=structlog.stdlib.BoundLogger,
             cache_logger_on_first_use=True,
-            processors=[
-                structlog.stdlib.filter_by_level,
-                structlog.stdlib.add_logger_name,
-                structlog.stdlib.add_log_level,
-                structlog.stdlib.PositionalArgumentsFormatter(),
-                structlog.processors.StackInfoRenderer(),
-                structlog.processors.format_exc_info,
-                structlog.processors.UnicodeDecoder(),
-                structlog.stdlib.render_to_log_kwargs,
-            ],
+            processors=[structlog.stdlib.filter_by_level]
+            + pre_chain
+            + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter],
         )
+
+        formatter = structlog.stdlib.ProcessorFormatter(
+            processor=structlog.processors.JSONRenderer(), foreign_pre_chain=pre_chain
+        )
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        root_logger = logging.getLogger()
+        root_logger.handlers.clear()
+        root_logger.addHandler(handler)
+        root_logger.setLevel(level)
+
+        # Some loggers have existing handlers that need to be overridden
+        if override_logs:
+            for log_name in override_logs:
+                access_logger = logging.getLogger(log_name)
+                access_logger.handlers.clear()
+                access_logger.addHandler(handler)
+                access_logger.setLevel(level)
 
     # Unless the user specifies higher verbosity than we have levels, turn down the log level
     # for external libraries.

--- a/src/miscutils/logging_config.py
+++ b/src/miscutils/logging_config.py
@@ -36,6 +36,7 @@ class Verbosity(IntEnum):
         v = self.value
         return VERBOSE_LEVELS[v] if v < len(VERBOSE_LEVELS) else VERBOSE_LEVELS[-1]
 
+
 def add_line_no(logger, method_name, event_dict):
     """
     Add the line number to the event dict.
@@ -44,6 +45,7 @@ def add_line_no(logger, method_name, event_dict):
     if record is not None:
         event_dict["lineno"] = record.lineno
     return event_dict
+
 
 def add_file_name(logger, method_name, event_dict):
     """
@@ -54,17 +56,6 @@ def add_file_name(logger, method_name, event_dict):
         event_dict["filename"] = record.filename
     return event_dict
 
-
-pre_chain = [
-    add_line_no,
-    add_file_name,
-    structlog.stdlib.add_logger_name,
-    structlog.stdlib.add_log_level,
-    structlog.stdlib.PositionalArgumentsFormatter(),
-    structlog.processors.StackInfoRenderer(),
-    structlog.processors.format_exc_info,
-    structlog.processors.UnicodeDecoder(),
-]
 
 
 def default_logging(
@@ -92,9 +83,26 @@ def default_logging(
             logger_factory=structlog.stdlib.LoggerFactory(),
             wrapper_class=structlog.stdlib.BoundLogger,
             cache_logger_on_first_use=True,
-            processors=pre_chain,
+            processors=[
+                structlog.stdlib.filter_by_level,
+                structlog.stdlib.PositionalArgumentsFormatter(),
+                structlog.processors.StackInfoRenderer(),
+                structlog.processors.format_exc_info,
+                structlog.processors.UnicodeDecoder(),
+                structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+            ],
         )
     elif log_format == LogFormat.JSON:
+        pre_chain = [
+            add_line_no,
+            add_file_name,
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.processors.UnicodeDecoder(),
+        ]
         structlog.configure(
             context_class=structlog.threadlocal.wrap_dict(dict),
             logger_factory=structlog.stdlib.LoggerFactory(),

--- a/tests/miscutils/test_logging_config.py
+++ b/tests/miscutils/test_logging_config.py
@@ -31,12 +31,10 @@ class TestDefaultConfiguration:
         mock_configure.assert_called_once()
 
     @patch("structlog.configure")
-    @patch("logging.config.dictConfig")
-    def test_json_logging(self, mock_dict_config, mock_configure):
+    def test_json_logging(self, mock_configure):
         under_test.default_logging(
             under_test.Verbosity.WARNING, log_format=under_test.LogFormat.JSON
         )
-        mock_dict_config.assert_called_once()
         mock_configure.assert_called_once()
 
     @patch("logging.getLogger")
@@ -48,3 +46,12 @@ class TestDefaultConfiguration:
         )
         mock_get_logger.assert_called_with("some_external_log")
         mock_get_logger.return_value.setLevel.assert_called_with(logging.WARNING)
+
+    @patch("logging.getLogger")
+    def test_override_logs(self, mock_get_logger):
+        under_test.default_logging(
+            under_test.Verbosity.DEBUG,
+            under_test.LogFormat.JSON,
+            override_logs=["some_log_needing_override"],
+        )
+        mock_get_logger.assert_called_with("some_log_needing_override")


### PR DESCRIPTION
Before:
```
{"message": "change point detection requested", "lineno": 79, "filename": "api.py", "logger": "signal_processing_service.api", "level": "info"}
{"message": "compute_change_points", "lineno": 253, "filename": "e_divisive_numpy.py", "logger": "signal_processing_algorithms.e_divisive_numpy", "level": "info"}
{"message": "returning change points", "lineno": 93, "filename": "api.py", "logger": "signal_processing_service.api", "level": "info"}
```

After:
```
{"event": "Started server process [9955]", "lineno": 389, "filename": "main.py", "logger": "uvicorn.error", "level": "info"}
{"event": "Uvicorn running on http://0.0.0.0:8080 (Press CTRL+C to quit)", "lineno": 471, "filename": "main.py", "logger": "uvicorn.error", "level": "info"}
{"event": "Waiting for application startup.", "lineno": 22, "filename": "on.py", "logger": "uvicorn.error", "level": "info"}
{"event": "Application startup complete.", "lineno": 34, "filename": "on.py", "logger": "uvicorn.error", "level": "info"}
{"event": "change point detection requested", "logger": "signal_processing_service.api", "level": "info"}
{"event": "compute_change_points", "logger": "signal_processing_algorithms.e_divisive_numpy", "level": "info"}
{"event": "returning change points", "logger": "signal_processing_service.api", "level": "info"}
{"event": "127.0.0.1:51016 - \"POST /change_points/detect HTTP/1.1\" 200", "lineno": 454, "filename": "httptools_impl.py", "logger": "uvicorn.access", "level": "info"}
```